### PR TITLE
Isochronous transactions loose fix

### DIFF
--- a/libusb/os/windows_nt_common.c
+++ b/libusb/os/windows_nt_common.c
@@ -506,8 +506,12 @@ void windows_handle_callback(struct usbi_transfer *itransfer, uint32_t io_result
 	case LIBUSB_TRANSFER_TYPE_CONTROL:
 	case LIBUSB_TRANSFER_TYPE_BULK:
 	case LIBUSB_TRANSFER_TYPE_INTERRUPT:
-	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
 		windows_transfer_callback(itransfer, io_result, io_size);
+		break;
+	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
+		 /* Isoc transfer status will be checked later (in winusbx_iso_transfer_continue_stream_callback)
+		 * per every isoc packet basis */
+		windows_transfer_callback(itransfer, NO_ERROR, io_size);
 		break;
 	case LIBUSB_TRANSFER_TYPE_BULK_STREAM:
 		usbi_warn(ITRANSFER_CTX(itransfer), "bulk stream transfers are not yet supported on this platform");

--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -2977,15 +2977,17 @@ static void WINAPI winusbx_iso_transfer_continue_stream_callback(struct libusb_t
 
 	struct windows_transfer_priv *transfer_priv = (struct windows_transfer_priv *)
 			usbi_transfer_get_os_priv(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
-	BOOL fallback = (transfer->status != LIBUSB_TRANSFER_COMPLETED);
+	BOOL fallback = TRUE;
 	int idx;
 
 	// Restore the user callback
 	transfer->callback = transfer_priv->iso_user_callback;
 
-	for (idx = 0; idx < transfer->num_iso_packets && !fallback; ++idx) {
-		if (transfer->iso_packet_desc[idx].status != LIBUSB_TRANSFER_COMPLETED) {
-			fallback = TRUE;
+	for (idx = 0; idx < transfer->num_iso_packets; ++idx) {
+		if (transfer->iso_packet_desc[idx].status == LIBUSB_TRANSFER_COMPLETED) {
+			/* at least one isoc packet completed, so all transaction is success then */
+			fallback = FALSE;
+			break;
 		}
 	}
 


### PR DESCRIPTION
Do not rely on transfer->status for Isochronous transactions but
check every isoc packet status inside transaction.

Sometimes Isochronous transaction partially filled and has
transfer->status=ERROR_GEN_FAILURE but there is some isoc packets inside
with correct data and transfer->iso_packet_desc[idx].status == LIBUSB_TRANSFER_COMPLETED
We should not discard this transactions.

Signed-off-by: Abylay Ospan <aospan@jokersys.com>